### PR TITLE
show usage of mdsnippets

### DIFF
--- a/mdsnippets.json
+++ b/mdsnippets.json
@@ -1,0 +1,5 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/SimonCropp/MarkdownSnippets/master/schema.json",
+  "Convention": "InPlaceOverwrite",
+  "MaxWidth": 120
+}

--- a/src/XenoAtom.Allocators.Bench/BenchAllocator.cs
+++ b/src/XenoAtom.Allocators.Bench/BenchAllocator.cs
@@ -18,7 +18,7 @@ public class BenchAllocator
     private Random _random = new Random();
 
     private static int[] AllocSizes = [64, 96, 150, 200, 400, 1024, 4096];
-    
+
     private const int AllocationCount = 2048;
 
     [GlobalSetup]
@@ -80,11 +80,13 @@ public class BenchAllocator
         }
     }
 
+    #region BasicChunkAllocator
+
     private unsafe class BasicChunkAllocator : IMemoryChunkAllocator
     {
-        private readonly Dictionary<int, MemoryChunk> _chunks = new Dictionary<int, MemoryChunk>();
+        private readonly Dictionary<int, MemoryChunk> _chunks = new();
         private const int ChunkSize = 65536;
-        
+
         public bool TryAllocateChunk(MemorySize minSize, out MemoryChunk chunk)
         {
             var blockSize = (uint)Math.Max(ChunkSize, (int)minSize.Value);
@@ -101,4 +103,6 @@ public class BenchAllocator
             _chunks.Remove((int)chunkId.Value);
         }
     }
+
+    #endregion
 }

--- a/src/XenoAtom.Allocators.Tests/XenoAtom.Allocators.Tests.csproj
+++ b/src/XenoAtom.Allocators.Tests/XenoAtom.Allocators.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MarkdownSnippets.MsBuild" Version="27.0.2" PrivateAssets="all" />
     <PackageReference Include="MSTest" Version="3.*" />
     <PackageReference Include="Verify.DiffPlex" Version="3.1.0" />
     <PackageReference Include="Verify.MSTest" Version="25.3.0" />

--- a/src/XenoAtom.Allocators/TlsfAllocation.cs
+++ b/src/XenoAtom.Allocators/TlsfAllocation.cs
@@ -4,6 +4,8 @@
 
 namespace XenoAtom.Allocators;
 
+#region TlsfAllocation
+
 /// <summary>
 /// An allocation from a <see cref="TlsfAllocator"/> returned by <see cref="TlsfAllocator.Allocate"/>.
 /// </summary>
@@ -26,7 +28,7 @@ public readonly record struct TlsfAllocation
     /// Gets the chunk id of this allocated block belongs to.
     /// </summary>
     public readonly MemoryChunkId ChunkId;
-    
+
     /// <summary>
     /// Gets the address of the allocated block.
     /// </summary>
@@ -42,3 +44,5 @@ public readonly record struct TlsfAllocation
     /// </summary>
     public static implicit operator TlsfAllocationToken (TlsfAllocation allocation) => allocation.Token;
 }
+
+#endregion


### PR DESCRIPTION
https://github.com/SimonCropp/MarkdownSnippets

prevents docs from getting out of sync with code. 

u can see in the diff, the docs for TlsfAllocation were already out of sync
