### PR TITLE
Fix: Incorrect block skipping in TryFindSuitableBlock when searching higher first-level bins

### DIFF
--- a/src/XenoAtom.Allocators.Tests/BasicTests.cs
+++ b/src/XenoAtom.Allocators.Tests/BasicTests.cs
@@ -549,6 +549,58 @@ public partial class BasicTests
         await Verify();
     }
 
+    [TestMethod]
+    public async Task TestLargeAllocation()
+    {
+        Recording.Start();
+
+        var allocator = new TlsfChunkAllocatorTestInstance(BaseAddress, BaseChunkSize);
+
+        MemorySize alignment = 64;
+        var tlsf = new TlsfAllocator(allocator, alignment);
+
+        Assert.AreEqual(0, tlsf.Chunks.Length);
+
+        MemorySize size1 = 32768;
+        MemorySize size2 = 17408;
+        var allocation1 = tlsf.Allocate(size1);
+        var allocation2 = tlsf.Allocate(size2);
+
+        // General checks
+        Assert.AreEqual(1, allocator.RequestedChunkAllocations.Count);
+        Assert.AreEqual(1, tlsf.Chunks.Length);
+        Assert.AreEqual((MemoryChunkId)0, tlsf.Chunks[0].Info.Id);
+        Assert.AreEqual(BaseAddress, tlsf.Chunks[0].Info.BaseAddress);
+        Assert.AreEqual(BaseChunkSize, tlsf.Chunks[0].Info.Size);
+        Assert.AreEqual(2U, tlsf.Chunks[0].UsedBlockCount);
+        Assert.AreEqual(1U, tlsf.Chunks[0].FreeBlockCount);
+        Assert.AreEqual(allocation1.Size + allocation2.Size, tlsf.Chunks[0].TotalAllocated);
+
+        // Allocation 1
+        Assert.AreEqual(BaseAddress, allocation1.Address);
+        Assert.AreEqual(size1, allocation1.Size);
+
+        // Allocation 2
+        Assert.AreEqual(BaseAddress + size1, allocation2.Address);
+        Assert.AreEqual(size2, allocation2.Size);
+
+        AddRecording(tlsf, "01-Allocations");
+
+        tlsf.Free(allocation1);
+        tlsf.Free(allocation2);
+        Assert.AreEqual(0U, tlsf.Chunks[0].UsedBlockCount);
+        Assert.AreEqual(1U, tlsf.Chunks[0].FreeBlockCount);
+
+        AddRecording(tlsf, "02-Free Allocations");
+
+        // Resets the allocator (free chunks)
+        tlsf.Reset();
+        Assert.AreEqual(0, tlsf.Chunks.Length);
+        Assert.AreEqual(0, allocator.RequestedChunkAllocations.Count);
+
+        await Verify();
+    }
+
     private void AddRecording(TlsfAllocator tlsf, string stepName)
     {
         var builder = new StringBuilder("    ");

--- a/src/XenoAtom.Allocators.Tests/Verified/BasicTests.TestLargeAllocation.verified.txt
+++ b/src/XenoAtom.Allocators.Tests/Verified/BasicTests.TestLargeAllocation.verified.txt
@@ -1,0 +1,57 @@
+{
+  01-Allocations:
+    TLSF Allocator
+    ==============
+    
+    Alignment: 64
+    
+    Chunks:  1
+    ----------
+    Chunk MemoryChunkId(0x0):
+      BaseAddress: MemoryAddress(0xFE00120000000000)
+      Size: MemorySize(65536)
+      TotalAllocated: MemorySize(50176)
+      UsedBlockCount: 2
+      FreeBlockCount: 1
+      FirstBlockInPhysicalOrder: 1
+    
+    Bins: 0b0000_0000_0000_0000_0000_0000_0000_1000
+    ----------------------------------------
+    Bin L1 (3): [0x1000, 0x1fff[ -> Mask: 0b0000_0000_0000_0001
+      Bin L2 (0): [0x1000, 0x10ff[ -> FirstFreeBlock: 0
+    
+    Blocks:   3
+    -----------
+     Block Chunk Offset   Size Status     Free Links     Phys Links
+       [0]     0  50176  15360   Free     -1 <->  -1      2 <->  -1
+       [1]     0      0  32768   Used     -1 <->  -1     -1 <->   2
+       [2]     0  32768  17408   Used     -1 <->  -1      1 <->   0
+    ,
+  02-Free Allocations:
+    TLSF Allocator
+    ==============
+    
+    Alignment: 64
+    
+    Chunks:  1
+    ----------
+    Chunk MemoryChunkId(0x0):
+      BaseAddress: MemoryAddress(0xFE00120000000000)
+      Size: MemorySize(65536)
+      TotalAllocated: MemorySize(0)
+      UsedBlockCount: 0
+      FreeBlockCount: 1
+      FirstBlockInPhysicalOrder: 2
+    
+    Bins: 0b0000_0000_0000_0000_0000_0000_0100_0000
+    ----------------------------------------
+    Bin L1 (6): [0x8000, 0xffff[ -> Mask: 0b0000_0000_0000_0001
+      Bin L2 (0): [0x8000, 0x87ff[ -> FirstFreeBlock: 2
+    
+    Blocks:   3
+    -----------
+     Block Chunk Offset   Size Status     Free Links     Phys Links
+     [0-1]                      Avail                              
+       [2]     0      0  65536   Free     -1 <->  -1     -1 <->  -1
+    
+}

--- a/src/XenoAtom.Allocators/TlsfAllocator.cs
+++ b/src/XenoAtom.Allocators/TlsfAllocator.cs
@@ -560,9 +560,14 @@ public sealed unsafe class TlsfAllocator
 
     private ref Block TryFindSuitableBlock(uint size, ref int firstLevelIndex, ref int secondLevelIndex, out int blockIndex)
     {
-        findFirstLevel:
+        int originalFirstLevelIndex = firstLevelIndex;
         firstLevelIndex = _bins.GetFirstLevelIndexAvailableAt(firstLevelIndex);
+        if (firstLevelIndex > originalFirstLevelIndex)
+        {
+            secondLevelIndex = 0;
+        }
 
+        findFirstLevel:
         // If we don't have a block in higher level directory, we need to allocate a new chunk
         if (firstLevelIndex < 0)
         {
@@ -612,8 +617,8 @@ public sealed unsafe class TlsfAllocator
             // to 1) find an existing level directory with a free block or 2) allocate a new chunk
             if (localSecondLevelIndex < 0)
             {
+                firstLevelIndex = _bins.GetFirstLevelIndexAvailableAt(firstLevelIndex + 1);
                 secondLevelIndex = 0;
-                firstLevelIndex++;
                 goto findFirstLevel;
             }
 
@@ -629,8 +634,8 @@ public sealed unsafe class TlsfAllocator
             // In both cases, the first level is 3, and the second level is 0, but the block with a size of (16384 - 128) is not enough for the requested size (16384 - 64)
             if (block.Size < size)
             {
+                firstLevelIndex = _bins.GetFirstLevelIndexAvailableAt(firstLevelIndex + 1);
                 secondLevelIndex = 0;
-                firstLevelIndex++;
                 goto findFirstLevel;
             }
             return ref block;


### PR DESCRIPTION
## Problem
In some cases, for sufficiently large single memory allocations, the allocator may skip certain blocks that meet the criteria and instead allocate a new chunk, resulting in memory waste.

## Verification
A test case `TestLargeAllocation` was added to reproduce the issue.

```csharp
var allocation1 = tlsf.Allocate(32768);
var allocation2 = tlsf.Allocate(17408);
```

## Previous output
```
{
  01-Allocations:
    TLSF Allocator
    ==============
    
    Alignment: 64
    
    Chunks:  2
    ----------
    Chunk MemoryChunkId(0x0):
      BaseAddress: MemoryAddress(0xFE00120000000000)
      Size: MemorySize(65536)
      TotalAllocated: MemorySize(32768)
      UsedBlockCount: 1
      FreeBlockCount: 1
      FirstBlockInPhysicalOrder: 1
    
    Chunk MemoryChunkId(0x1):
      BaseAddress: MemoryAddress(0xFE00120000010000)
      Size: MemorySize(65536)
      TotalAllocated: MemorySize(17408)
      UsedBlockCount: 1
      FreeBlockCount: 1
      FirstBlockInPhysicalOrder: 3
    
    Bins: 0b0000_0000_0000_0000_0000_0000_0010_0000
    ----------------------------------------
    Bin L1 (5): [0x4000, 0x7fff[ -> Mask: 0b0000_0000_1000_0001
      Bin L2 (0): [0x4000, 0x43ff[ -> FirstFreeBlock: 0
      Bin L2 (7): [0x5c00, 0x5fff[ -> FirstFreeBlock: 2
    
    Blocks:   4
    -----------
     Block Chunk Offset   Size Status     Free Links     Phys Links
       [0]     0  32768  32768   Free     -1 <->  -1      1 <->  -1
       [1]     0      0  32768   Used     -1 <->  -1     -1 <->   0
       [2]     1  17408  48128   Free     -1 <->  -1      3 <->  -1
       [3]     1      0  17408   Used     -1 <->  -1     -1 <->   2
    
}
```

## Expected output
```
{
  01-Allocations:
    TLSF Allocator
    ==============
    
    Alignment: 64
    
    Chunks:  1
    ----------
    Chunk MemoryChunkId(0x0):
      BaseAddress: MemoryAddress(0xFE00120000000000)
      Size: MemorySize(65536)
      TotalAllocated: MemorySize(50176)
      UsedBlockCount: 2
      FreeBlockCount: 1
      FirstBlockInPhysicalOrder: 1
    
    Bins: 0b0000_0000_0000_0000_0000_0000_0000_1000
    ----------------------------------------
    Bin L1 (3): [0x1000, 0x1fff[ -> Mask: 0b0000_0000_0000_0001
      Bin L2 (0): [0x1000, 0x10ff[ -> FirstFreeBlock: 0
    
    Blocks:   3
    -----------
     Block Chunk Offset   Size Status     Free Links     Phys Links
       [0]     0  50176  15360   Free     -1 <->  -1      2 <->  -1
       [1]     0      0  32768   Used     -1 <->  -1     -1 <->   2
       [2]     0  32768  17408   Used     -1 <->  -1      1 <->   0
    
}
```